### PR TITLE
Fix Unreasonably High Duration Between Lock & Unlock

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32;
 
 class Program
 {
-    private static DateTime lockTime;
+    private static DateTime lockTime = DateTime.Now;
     private static DateTime unlockTime;
     private static NotifyIcon notifyIcon;
 


### PR DESCRIPTION
This pull request fixes a bug where the time between lock and unlock was showing an unreasonably high duration, like `739270d 13h 47m 38s`.